### PR TITLE
Update AgentControlPlaneReconciler and ClusterDeploymentReconciler

### DIFF
--- a/controlplane/internal/controller/agentclusterinstall_controller.go
+++ b/controlplane/internal/controller/agentclusterinstall_controller.go
@@ -22,10 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1beta1"
-	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
-	aimodels "github.com/openshift/assisted-service/models"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +32,11 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1beta1"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	aimodels "github.com/openshift/assisted-service/models"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
 // AgentClusterInstallReconciler reconciles a AgentClusterInstall object
@@ -159,6 +160,13 @@ func (r *AgentClusterInstallReconciler) ClusterKubeconfigSecretExists(ctx contex
 		return !apierrors.IsNotFound(err)
 	}
 	return true
+}
+
+func IsAgentControlPlaneReferencingClusterDeployment(agentCP v1beta1.AgentControlPlane, clusterDeployment *hivev1.ClusterDeployment) bool {
+	return agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef != nil &&
+		agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef.GroupVersionKind().String() == hivev1.SchemeGroupVersion.WithKind("ClusterDeployment").String() &&
+		agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef.Namespace == clusterDeployment.Namespace &&
+		agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef.Name == clusterDeployment.Name
 }
 
 // GenerateSecretWithOwner returns a Kubernetes secret for the given Cluster name, namespace, kubeconfig data, and ownerReference.

--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -19,16 +19,19 @@ package controller
 import (
 	"context"
 
-	"github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1beta1"
-	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1beta1"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
 // ClusterDeploymentReconciler reconciles a ClusterDeployment object
@@ -55,49 +58,63 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	log.Info("Reconciling ClusterDeployment", "name", clusterDeployment.Name, "namespace", clusterDeployment.Namespace)
+	// reconcile only in case the clusterdeployment is owned by AgentControlPlane
 
-	agentCPList := &v1beta1.AgentControlPlaneList{}
-	if err := r.Client.List(ctx, agentCPList, client.InNamespace(clusterDeployment.Namespace)); err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
+	// Check if the resource has owner references
+	agentControlPlaneKindOwnerRef := false
+	if len(clusterDeployment.OwnerReferences) > 0 {
+		for _, ownerRef := range clusterDeployment.OwnerReferences {
+			if ownerRef.Kind == agentControlPlaneKind {
+				log.Info("clusterDeployment has an owner reference with agentControlPlaneKind, reconciling\n",
+					"namespace:", clusterDeployment.Namespace, "name:", clusterDeployment.Name, "ownerRef:", ownerRef.Name)
+				agentControlPlaneKindOwnerRef = true
+				break
+			}
 		}
+	}
+	if !agentControlPlaneKindOwnerRef {
+		log.Info("clusterDeployment %s %sisn't owned by AgentControlPlane", "namespace:", clusterDeployment.Namespace, "name:", clusterDeployment.Name)
+		return ctrl.Result{}, nil
+	}
+
+	acp := &v1beta1.AgentControlPlane{}
+	// Note we assume the same name and namespace for the ACP and clsuterDeployment
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: clusterDeployment.Namespace, Name: clusterDeployment.Name}, acp); err != nil {
 		return ctrl.Result{}, err
 	}
-	log.Info("found agentcontrolplane", "num", len(agentCPList.Items))
 
-	if len(agentCPList.Items) == 0 {
-		return ctrl.Result{}, nil
+	imageSetName, err := r.ensureClusterImageSet(ctx, log, clusterDeployment, acp)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-	for _, agentCP := range agentCPList.Items {
-		if IsAgentControlPlaneReferencingClusterDeployment(agentCP, clusterDeployment) {
-			log.Info("ClusterDeployment is referenced by AgentControlPlane")
-			return r.ensureAgentClusterInstall(ctx, clusterDeployment, agentCP)
+	return ctrl.Result{}, r.ensureAgentClusterInstall(ctx, log, clusterDeployment, acp, imageSetName)
+}
+
+func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(ctx context.Context, log logr.Logger, clusterDeployment *hivev1.ClusterDeployment, acp *v1beta1.AgentControlPlane, imageSetName string) error {
+	log.Info("Setting AgentClusterInstall")
+	agentClusterInstall := &hiveext.AgentClusterInstall{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: clusterDeployment.Namespace, Name: clusterDeployment.Name}, agentClusterInstall); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to get AgentClusterInstall")
+			return err
+		}
+		err = r.createAgentClusterInstall(ctx, log, clusterDeployment, acp, imageSetName)
+		if err != nil {
+			log.Error(err, "failed to create AgentClusterInstall")
+			return err
 		}
 	}
-	log.Info("No agentcontrolplane is referenced by ClusterDeployment", "name", clusterDeployment.Name, "namespace", clusterDeployment.Namespace)
-
-	return ctrl.Result{}, nil
-}
-
-func IsAgentControlPlaneReferencingClusterDeployment(agentCP v1beta1.AgentControlPlane, clusterDeployment *hivev1.ClusterDeployment) bool {
-	return agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef != nil &&
-		agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef.GroupVersionKind().String() == hivev1.SchemeGroupVersion.WithKind("ClusterDeployment").String() &&
-		agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef.Namespace == clusterDeployment.Namespace &&
-		agentCP.Spec.AgentConfigSpec.ClusterDeploymentRef.Name == clusterDeployment.Name
-}
-
-func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(ctx context.Context, clusterDeployment *hivev1.ClusterDeployment, acp v1beta1.AgentControlPlane) (ctrl.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-
-	if clusterDeployment.Spec.ClusterInstallRef != nil {
-		log.Info(
-			"Skipping reconciliation: cluster deployment already has a referenced agent cluster install",
-			"cluster_deployment_name", clusterDeployment.Name,
-			"cluster_deployment_namespace", clusterDeployment.Namespace,
-			"agent_cluster_install", clusterDeployment.Spec.ClusterInstallRef.Name,
-		)
-		return ctrl.Result{}, nil
+	// TODO: consider removing this as it should already be set on the CD upon creation
+	clusterDeployment.Spec.ClusterInstallRef = &hivev1.ClusterInstallLocalReference{
+		Group:   hiveext.Group,
+		Version: hiveext.Version,
+		Kind:    "AgentClusterInstall",
+		Name:    agentClusterInstall.Name,
 	}
+	return r.Client.Update(ctx, clusterDeployment)
+}
+
+func (r *ClusterDeploymentReconciler) ensureClusterImageSet(ctx context.Context, log logr.Logger, clusterDeployment *hivev1.ClusterDeployment, acp *v1beta1.AgentControlPlane) (string, error) {
 	imageSet := &hivev1.ClusterImageSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterDeployment.Name,
@@ -108,11 +125,15 @@ func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(ctx context.Cont
 		},
 	}
 	if err := r.Client.Create(ctx, imageSet); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			log.Info("ImageSet already exists", "name", imageSet.Name, "namespace", imageSet.Namespace)
-			return ctrl.Result{}, err
+		if !apierrors.IsAlreadyExists(err) { // ignore already exists error
+			log.Error(err, "Error creating clusterImageSet ", "name", imageSet.Name, "namespace", imageSet.Namespace)
+			return "", err
 		}
 	}
+	return clusterDeployment.Name, nil
+}
+
+func (r *ClusterDeploymentReconciler) createAgentClusterInstall(ctx context.Context, log logr.Logger, clusterDeployment *hivev1.ClusterDeployment, acp *v1beta1.AgentControlPlane, imageSetName string) error {
 
 	log.Info("Creating agent cluster install for ClusterDeployment", "name", clusterDeployment.Name, "namespace", clusterDeployment.Namespace)
 	agentClusterInstall := &hiveext.AgentClusterInstall{
@@ -126,18 +147,14 @@ func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(ctx context.Cont
 				ControlPlaneAgents: int(acp.Spec.Replicas),
 			},
 			SSHPublicKey: acp.Spec.AgentConfigSpec.SSHAuthorizedKey,
-			ImageSetRef:  &hivev1.ClusterImageSetReference{Name: imageSet.Name},
+			ImageSetRef:  &hivev1.ClusterImageSetReference{Name: imageSetName},
 		},
 	}
-	if err := r.Client.Create(ctx, agentClusterInstall); err != nil {
-		return ctrl.Result{}, err
+	// TODO: convert this to create or update
+	err := r.Client.Create(ctx, agentClusterInstall)
+	if !apierrors.IsAlreadyExists(err) { // ignore already exists error
+		log.Error(err, "Error creating AgentClusterInstall ", "name", agentClusterInstall.Name, "namespace", agentClusterInstall.Namespace)
+		return err
 	}
-	clusterDeployment.Spec.ClusterInstallRef = &hivev1.ClusterInstallLocalReference{
-		Group:   hiveext.Group,
-		Version: hiveext.Version,
-		Kind:    "AgentClusterInstall",
-		Name:    agentClusterInstall.Name,
-	}
-	err := r.Client.Update(ctx, clusterDeployment)
-	return ctrl.Result{}, err
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/openshift/assisted-service/api v0.0.0
+	github.com/openshift/assisted-service/models v0.0.0
 	github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.29.3
@@ -64,7 +65,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/openshift/api v0.0.0-20220831183848-09c070622e2c // indirect
 	github.com/openshift/assisted-service v1.0.10-0.20230830164851-6573b5d7021d // indirect
-	github.com/openshift/assisted-service/models v0.0.0 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect


### PR DESCRIPTION
Update AgentControlPlaneReconciler to pass the HIVE clusterdeployment_validating_admission_hook by setting the clusterInfallRef when creating the clusterDeployment

Also refactored ClusterDeploymentReconciler to ensure the ACI and clusterImageSet exists regardless of the reference in the clusterDeployment