### PR TITLE
MGMT-17963: Enable pull-through cache setup

### DIFF
--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -274,6 +274,7 @@ func computeAgentClusterInstall(clusterDeployment *hivev1.ClusterDeployment, acp
 				ClusterNetwork: clusterNetwork,
 				ServiceNetwork: serviceNetwork,
 			},
+			ManifestsConfigMapRefs: acp.Spec.AgentConfigSpec.ManifestsConfigMapRefs,
 		},
 	}
 	return aci


### PR DESCRIPTION
The agent cluster install already allows users to provide post-install manifests. This enables these manifests to be passed through to the agentclusterinstall.

If a user wanted to use a pull-through cache, here's the configmap they'd need to provide

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: image-config
data:
  image-config.yaml: |
    apiVersion: config.openshift.io/v1
    kind: Image
    metadata:
      name: cluster
    spec:
      registrySources:
        insecureRegistries:
        - 10.1.178.25:5000
      additionalTrustedCA:
        name: trusted-ca
  test-ca.yaml: |
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: trusted-ca
      namespace: openshift-config
    data:
      registry.example.com: |
        -----BEGIN CERTIFICATE-----
        ...
        -----END CERTIFICATE-----
  idms.yaml: |
    apiVersion: config.openshift.io/v1
    kind: ImageDigestMirrorSet
    metadata:
      name: dockerio-mirror
    spec:
      imageDigestMirrors:
      - mirrors:
        - 10.1.178.25:5000
        source: quay.io
```
