### PR TITLE
bugfix: map cluster API v1beta1 to agent provider v1alpha1 version

### DIFF
--- a/bootstrap/config/crd/kustomization.yaml
+++ b/bootstrap/config/crd/kustomization.yaml
@@ -11,4 +11,4 @@ kind: Kustomization
 labels:
 - includeSelectors: true
   pairs:
-    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta1: v1alpha1

--- a/controlplane/config/crd/kustomization.yaml
+++ b/controlplane/config/crd/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 labels:
 - includeSelectors: true
   pairs:
-    cluster.x-k8s.io/v1beta1: v1beta1
+    cluster.x-k8s.io/v1beta1: v1alpha1


### PR DESCRIPTION
This maps cluster API apiversion with our provider's, otherwise cluster API controller cannot select our resources.