### PR TITLE
MGMT-17963: Return clearer error messages for image registry

### DIFF
--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -36,7 +36,6 @@ import (
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
@@ -277,23 +276,11 @@ func (r *ClusterDeploymentReconciler) computeAgentClusterInstall(
 	}
 
 	if acp.Spec.AgentConfigSpec.ImageRegistryRef != nil {
-		registryConfigmap := &corev1.ConfigMap{}
-		if err := r.Client.Get(ctx, client.ObjectKey{Name: acp.Spec.AgentConfigSpec.ImageRegistryRef.Name, Namespace: acp.Namespace}, registryConfigmap); err != nil {
-			return nil, err
-		}
-
-		spokeImageRegistryConfigmap, err := imageregistry.CreateImageRegistryConfigmap(registryConfigmap, acp.Namespace)
-		if err != nil {
-			return nil, err
-		}
-
-		_ = controllerutil.SetOwnerReference(&acp, spokeImageRegistryConfigmap, r.Scheme)
-
-		if _, err := ctrl.CreateOrUpdate(ctx, r.Client, spokeImageRegistryConfigmap, func() error { return nil }); err != nil && !apierrors.IsAlreadyExists(err) {
+		if err := r.createImageRegistry(ctx, acp.Spec.AgentConfigSpec.ImageRegistryRef.Name, acp.Namespace); err != nil {
 			log.Error(err, "failed to create image registry config manifest")
 			return nil, err
 		}
-		additionalManifests = append(additionalManifests, hiveext.ManifestsConfigMapReference{Name: spokeImageRegistryConfigmap.Name})
+		additionalManifests = append(additionalManifests, hiveext.ManifestsConfigMapReference{Name: imageregistry.ImageConfigMapName})
 	}
 
 	aci := &hiveext.AgentClusterInstall{
@@ -328,4 +315,21 @@ func (r *ClusterDeploymentReconciler) computeAgentClusterInstall(
 		},
 	}
 	return aci, nil
+}
+
+func (r *ClusterDeploymentReconciler) createImageRegistry(ctx context.Context, registryName, registryNamespace string) error {
+	registryConfigmap := &corev1.ConfigMap{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: registryName, Namespace: registryNamespace}, registryConfigmap); err != nil {
+		return err
+	}
+
+	spokeImageRegistryConfigmap, err := imageregistry.GenerateImageRegistryConfigmap(registryConfigmap, registryNamespace)
+	if err != nil {
+		return err
+	}
+
+	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, spokeImageRegistryConfigmap, func() error { return nil }); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }

--- a/controlplane/internal/imageregistry/image_registry.go
+++ b/controlplane/internal/imageregistry/image_registry.go
@@ -6,6 +6,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,19 +17,19 @@ const (
 	imageRegistryName              = "additional-registry"
 	registryCertConfigMapName      = "additional-registry-certificate"
 	registryCertConfigMapNamespace = "openshift-config"
-	imageConfigMapName             = "additional-registry-config"
+	ImageConfigMapName             = "additional-registry-config"
 	imageDigestMirrorSetKey        = "image-digest-mirror-set.json"
 	imageTagMirrorSetKey           = "image-tag-mirror-set.json"
 	registryCertConfigMapKey       = "additional-registry-certificate.json"
 	imageConfigKey                 = "image-config.json"
 )
 
-// CreateImageRegistryConfigmap creates a ConfigMap containing the manifests for mirror registry configuration
+// GenerateImageRegistryConfigmap generates a ConfigMap containing the manifests for mirror registry configuration
 // to be created on the spoke cluster. The manifests that are in the ConfigMap include an ImageDigestMirrorSet CR
 // and/or an ImageTagMirrorSet CR with the mirror registry information, a ConfigMap containing the additional
 // trusted certificates for the mirror registry, and an image.config.openshift.io CR that references the
 // ConfigMap with the additional trusted certificate.
-func CreateImageRegistryConfigmap(imageRegistry *corev1.ConfigMap, namespace string) (*corev1.ConfigMap, error) {
+func GenerateImageRegistryConfigmap(imageRegistry *corev1.ConfigMap, namespace string) (*corev1.ConfigMap, error) {
 	data := make(map[string]string, 0)
 
 	registryConf, ok := imageRegistry.Data[registryConfKey]
@@ -71,7 +72,7 @@ func CreateImageRegistryConfigmap(imageRegistry *corev1.ConfigMap, namespace str
 
 	imageConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      imageConfigMapName,
+			Name:      ImageConfigMapName,
 			Namespace: namespace,
 		},
 		Data: data,
@@ -97,11 +98,11 @@ func getImageRegistries(registry string) (string, string, []string, error) {
 	// Parse toml and add mirror registry to image digest mirror set
 	tomlTree, err := toml.Load(registry)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, errors.Wrap(err, "failed to load value of registries.conf into toml tree; incorrectly formatted toml")
 	}
 	registriesTree, ok := tomlTree.Get("registry").([]*toml.Tree)
 	if !ok {
-		return "", "", nil, fmt.Errorf("failed to find registry in toml tree")
+		return "", "", nil, fmt.Errorf("failed to find registry key in toml tree")
 	}
 
 	idmsMirrors := make([]configv1.ImageDigestMirrors, 0)
@@ -112,10 +113,15 @@ func getImageRegistries(registry string) (string, string, []string, error) {
 	for _, registry := range registriesTree {
 		source, sourceExists := registry.Get("location").(string)
 		mirrorTrees, mirrorExists := registry.Get("mirror").([]*toml.Tree)
-		if !sourceExists || !mirrorExists {
-			continue
+		if !sourceExists {
+			return "", "", nil, fmt.Errorf("failed to parse image registry toml, missing registry location")
 		}
-		parseMirrorRegistries(&idmsMirrors, &itmsMirrors, mirrorTrees, &insecureRegistries, source)
+		if !mirrorExists {
+			return "", "", nil, fmt.Errorf("failed to parse image registry toml, missing registry.mirror in registries.conf")
+		}
+		if err := parseMirrorRegistries(&idmsMirrors, &itmsMirrors, mirrorTrees, &insecureRegistries, source); err != nil {
+			return "", "", nil, errors.Wrap(err, fmt.Sprintf("failed to parse image mirror registry toml for registry %s", source))
+		}
 	}
 
 	if len(idmsMirrors) < 1 && len(itmsMirrors) < 1 {
@@ -142,36 +148,43 @@ func parseMirrorRegistries(
 	mirrorTrees []*toml.Tree,
 	insecureRegistries *[]string,
 	source string,
-) {
-	itmsMirror := configv1.ImageTagMirrors{}
-	idmsMirror := configv1.ImageDigestMirrors{}
+) error {
+	itmsMirror := &configv1.ImageTagMirrors{}
+	idmsMirror := &configv1.ImageDigestMirrors{}
 	for _, mirrorTree := range mirrorTrees {
-		if mirror, ok := mirrorTree.Get("location").(string); ok {
-			if insecure, ok := mirrorTree.Get("insecure").(bool); ok && insecure {
-				*insecureRegistries = append(*insecureRegistries, mirror)
-			}
-			if pullFrom, ok := mirrorTree.Get("pull-from-mirror").(string); ok {
-				switch pullFrom {
-				case "tag-only":
-					itmsMirror.Source = source
-					itmsMirror.Mirrors = append(itmsMirror.Mirrors, configv1.ImageMirror(mirror))
-				case "digest-only":
-					idmsMirror.Source = source
-					idmsMirror.Mirrors = append(idmsMirror.Mirrors, configv1.ImageMirror(mirror))
-				}
-			} else {
-				// Default is pulling by digest
-				idmsMirror.Source = source
-				idmsMirror.Mirrors = append(idmsMirror.Mirrors, configv1.ImageMirror(mirror))
-			}
+		mirror, ok := mirrorTree.Get("location").(string)
+		if !ok {
+			return fmt.Errorf("missing mirror registry location key or the value of location is not a string")
 		}
+		if insecure, ok := mirrorTree.Get("insecure").(bool); ok && insecure {
+			*insecureRegistries = append(*insecureRegistries, mirror)
+		}
+		setPullPolicy(itmsMirror, idmsMirror, source, mirror, mirrorTree)
 	}
 	if len(itmsMirror.Mirrors) > 0 {
-		*itmsMirrors = append(*itmsMirrors, itmsMirror)
+		*itmsMirrors = append(*itmsMirrors, *itmsMirror)
 	}
 	if len(idmsMirror.Mirrors) > 0 {
-		*idmsMirrors = append(*idmsMirrors, idmsMirror)
+		*idmsMirrors = append(*idmsMirrors, *idmsMirror)
 	}
+	return nil
+}
+
+func setPullPolicy(itmsMirror *configv1.ImageTagMirrors, idmsMirror *configv1.ImageDigestMirrors, source, mirror string, mirrorTree *toml.Tree) {
+	if pullFrom, ok := mirrorTree.Get("pull-from-mirror").(string); ok {
+		switch pullFrom {
+		case "tag-only":
+			itmsMirror.Source = source
+			itmsMirror.Mirrors = append(itmsMirror.Mirrors, configv1.ImageMirror(mirror))
+		case "digest-only":
+			idmsMirror.Source = source
+			idmsMirror.Mirrors = append(idmsMirror.Mirrors, configv1.ImageMirror(mirror))
+		}
+		return
+	}
+	// Default is pulling by digest
+	idmsMirror.Source = source
+	idmsMirror.Mirrors = append(idmsMirror.Mirrors, configv1.ImageMirror(mirror))
 }
 
 func generateImageDigestMirrorSet(mirrors []configv1.ImageDigestMirrors) (string, error) {


### PR DESCRIPTION
Creates and returns error messages that indicate where the image registry creation failed.

Includes small refactoring of creating the registry configmap and test cleanup.