### PR TITLE
MGMT-17965: Ensure all created resources have owner references

### DIFF
--- a/bootstrap/internal/controller/agentbootstrapconfig_controller.go
+++ b/bootstrap/internal/controller/agentbootstrapconfig_controller.go
@@ -315,6 +315,7 @@ func (r *AgentBootstrapConfigReconciler) ensureInfraEnv(
 	}
 
 	infraEnv := assistedinstaller.GetInfraEnvFromConfig(infraEnvName, config, clusterDeployment)
+	_ = controllerutil.SetOwnerReference(config, infraEnv, r.Scheme)
 	err = r.Create(ctx, infraEnv)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err

--- a/controlplane/internal/controller/agentcontrolplane_controller.go
+++ b/controlplane/internal/controller/agentcontrolplane_controller.go
@@ -154,7 +154,7 @@ func (r *AgentControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	return r.reconcileReplicas(ctx, acp, cluster)
+	return ctrl.Result{}, r.reconcileReplicas(ctx, acp, cluster)
 }
 
 // Ensures dependencies are deleted before allowing the AgentControlPlane to be deleted
@@ -228,7 +228,7 @@ func (r *AgentControlPlaneReconciler) computeDesiredMachine(acp *controlplanev1a
 	}
 
 	// Note: by setting the ownerRef on creation we signal to the Machine controller that this is not a stand-alone Machine.
-	controllerutil.SetOwnerReference(acp, desiredMachine, r.Scheme)
+	_ = controllerutil.SetOwnerReference(acp, desiredMachine, r.Scheme)
 
 	// Set the in-place mutable fields.
 	// When we create a new Machine we will just create the Machine with those fields.
@@ -274,7 +274,8 @@ func (r *AgentControlPlaneReconciler) ensureClusterDeployment(
 ) error {
 	if acp.Status.ClusterDeploymentRef == nil {
 		clusterDeployment := assistedinstaller.GetClusterDeploymentFromConfig(acp, clusterName)
-		if err := r.Create(ctx, clusterDeployment); err != nil && !apierrors.IsAlreadyExists(err) {
+		_ = controllerutil.SetOwnerReference(acp, clusterDeployment, r.Scheme)
+		if _, err := ctrl.CreateOrUpdate(ctx, r.Client, clusterDeployment, func() error { return nil }); err != nil {
 			return err
 		}
 		ref, err := reference.GetReference(r.Scheme, clusterDeployment)
@@ -298,10 +299,10 @@ func (r *AgentControlPlaneReconciler) ensureClusterDeployment(
 	return nil
 }
 
-func (r *AgentControlPlaneReconciler) reconcileReplicas(ctx context.Context, acp *controlplanev1alpha1.AgentControlPlane, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+func (r *AgentControlPlaneReconciler) reconcileReplicas(ctx context.Context, acp *controlplanev1alpha1.AgentControlPlane, cluster *clusterv1.Cluster) error {
 	machines, err := collections.GetFilteredMachinesForCluster(ctx, r.Client, cluster, collections.OwnedMachines(acp))
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	numMachines := machines.Len()
@@ -319,7 +320,7 @@ func (r *AgentControlPlaneReconciler) reconcileReplicas(ctx context.Context, acp
 		}
 	}
 	updateReplicaStatus(acp, machines, created)
-	return ctrl.Result{}, kerrors.NewAggregate(errs)
+	return kerrors.NewAggregate(errs)
 }
 
 func (r *AgentControlPlaneReconciler) scaleUpControlPlane(ctx context.Context, acp *controlplanev1alpha1.AgentControlPlane, clusterName string) error {
@@ -329,6 +330,7 @@ func (r *AgentControlPlaneReconciler) scaleUpControlPlane(ctx context.Context, a
 		return err
 	}
 	bootstrapConfig := r.generateAgentBootstrapConfig(acp, clusterName, name)
+	_ = controllerutil.SetOwnerReference(acp, bootstrapConfig, r.Scheme)
 	if err := r.Client.Create(ctx, bootstrapConfig); err != nil {
 		conditions.MarkFalse(acp, controlplanev1alpha1.MachinesCreatedCondition, controlplanev1alpha1.BootstrapTemplateCloningFailedReason,
 			clusterv1.ConditionSeverityError, err.Error())
@@ -416,7 +418,7 @@ func (r *AgentControlPlaneReconciler) generateAgentBootstrapConfig(acp *controlp
 		Spec: *acp.Spec.AgentBootstrapConfigSpec.DeepCopy(),
 	}
 
-	controllerutil.SetOwnerReference(acp, bootstrapConfig, r.Scheme)
+	_ = controllerutil.SetOwnerReference(acp, bootstrapConfig, r.Scheme)
 	return bootstrapConfig
 }
 

--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -36,6 +36,7 @@ import (
 	capiutil "sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
@@ -285,6 +286,8 @@ func (r *ClusterDeploymentReconciler) computeAgentClusterInstall(
 		if err != nil {
 			return nil, err
 		}
+
+		_ = controllerutil.SetOwnerReference(&acp, spokeImageRegistryConfigmap, r.Scheme)
 
 		if _, err := ctrl.CreateOrUpdate(ctx, r.Client, spokeImageRegistryConfigmap, func() error { return nil }); err != nil && !apierrors.IsAlreadyExists(err) {
 			log.Error(err, "failed to create image registry config manifest")


### PR DESCRIPTION
Modifies the following:
- AgentBootstrapConfig owns InfraEnv
- AgentControlPlane owns ClusterDeployment and AgentBootstrapConfig
- ClusterDeployment controller owns ClusterImageSet and AgentClusterInstall