### PR TITLE
MGMT-18017: Refactor placeholder pull secret

### DIFF
--- a/controlplane/internal/auth/auth.go
+++ b/controlplane/internal/auth/auth.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Assisted-service expects the pull secret to
+// 1. Have .dockerconfigjson as a key
+// 2. Have the value of .dockerconfigjson be a base64-encoded JSON
+// 3. The JSON must have the key "auths" followed by repository with an "auth" key
+func GenerateFakePullSecret(name, namespace string) *corev1.Secret {
+	// placeholder:secret base64 encoded is cGxhY2Vob2xkZXI6c2VjcmV0Cg==
+	fakePullSecret := "{\"auths\":{\"fake-pull-secret\":{\"auth\":\"cGxhY2Vob2xkZXI6c2VjcmV0Cg==\"}}}"
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(fakePullSecret),
+		},
+	}
+}

--- a/controlplane/internal/auth/auth_test.go
+++ b/controlplane/internal/auth/auth_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Auth Suite")
+}
+
+var _ = Describe("GenerateFakePullSecret", func() {
+	const (
+		pullSecretName      = "test-pull-secret"
+		pullSecretNamespace = "test-namespace"
+	)
+
+	It("should successfully generate a fake pull secret", func() {
+		secret := GenerateFakePullSecret(pullSecretName, pullSecretNamespace)
+		Expect(secret).NotTo(BeNil())
+		Expect(secret.Data).To(HaveKey(".dockerconfigjson"))
+	})
+})

--- a/controlplane/internal/controller/agentcontrolplane_controller.go
+++ b/controlplane/internal/controller/agentcontrolplane_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift-assisted/cluster-api-agent/assistedinstaller"
 	bootstrapv1alpha1 "github.com/openshift-assisted/cluster-api-agent/bootstrap/api/v1alpha1"
 	controlplanev1alpha1 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha1"
+	"github.com/openshift-assisted/cluster-api-agent/controlplane/internal/auth"
 	"github.com/openshift-assisted/cluster-api-agent/util"
 	logutil "github.com/openshift-assisted/cluster-api-agent/util/log"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -428,7 +429,7 @@ func (r *AgentControlPlaneReconciler) ensurePullSecret(
 		return nil
 	}
 
-	secret := util.GenerateFakePullSecret(placeholderPullSecretName, acp.Namespace)
+	secret := auth.GenerateFakePullSecret(placeholderPullSecretName, acp.Namespace)
 	if err := controllerutil.SetOwnerReference(acp, secret, r.Scheme); err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -7,8 +7,6 @@ import (
 	controlplanev1alpha1 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha1"
 	logutil "github.com/openshift-assisted/cluster-api-agent/util/log"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/labels/format"
@@ -59,23 +57,4 @@ func ControlPlaneMachineLabelsForCluster(
 	// longer than 63 characters.
 	labels[clusterv1.MachineControlPlaneNameLabel] = format.MustFormatValue(acp.Name)
 	return labels
-}
-
-// Assisted-service expects the pull secret to
-// 1. Have .dockerconfigjson as a key
-// 2. Have the value of .dockerconfigjson be a base64-encoded JSON
-// 3. The JSON must have the key "auths" followed by repository with an "auth" key
-func GenerateFakePullSecret(name, namespace string) *corev1.Secret {
-	// placeholder:secret base64 encoded is cGxhY2Vob2xkZXI6c2VjcmV0Cg==
-	fakePullSecret := "{\"auths\":{\"fake-pull-secret\":{\"auth\":\"cGxhY2Vob2xkZXI6c2VjcmV0Cg==\"}}}"
-
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Data: map[string][]byte{
-			".dockerconfigjson": []byte(fakePullSecret),
-		},
-	}
 }


### PR DESCRIPTION
Moving the function to its own auth file as it's only used by the Agent Control Plane controller.