### PR TITLE
MGMT-19876: Detect upgrade

### DIFF
--- a/controlplane/api/v1alpha2/openshiftassistedcontrolplane_types.go
+++ b/controlplane/api/v1alpha2/openshiftassistedcontrolplane_types.go
@@ -154,6 +154,10 @@ type OpenshiftAssistedControlPlaneStatus struct {
 	// +optional
 	Version *string `json:"version,omitempty"`
 
+	// DistributionVersion represents the current OpenShift version installed on the
+	// control plane machines in the cluster.
+	DistributionVersion string `json:"distributionVersion,omitempty"`
+
 	// Total number of non-terminated machines targeted by this control plane
 	// that have the desired template spec.
 	// +optional

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_openshiftassistedcontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_openshiftassistedcontrolplanes.yaml
@@ -57,7 +57,7 @@ spec:
       type: date
     - description: OpenShift version associated with this control plane
       jsonPath: .spec.distributionVersion
-      name: DistributionVersion
+      name: Distribution Version
       type: string
     name: v1alpha2
     schema:
@@ -561,6 +561,11 @@ spec:
                   - type
                   type: object
                 type: array
+              distributionVersion:
+                description: |-
+                  DistributionVersion represents the current OpenShift version installed on the
+                  control plane machines in the cluster.
+                type: string
               failureMessage:
                 description: |-
                   ErrorMessage indicates that there is a terminal problem reconciling the

--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
@@ -560,7 +560,7 @@ func getWorkloadClient(ctx context.Context, client client.Client, oacp *controlp
 		return nil, fmt.Errorf("kubeconfig secret was not found")
 	}
 
-	kubeconfig, err := util.ExtractKubeconfigFromSecret(kubeconfigSecret)
+	kubeconfig, err := util.ExtractKubeconfigFromSecret(kubeconfigSecret, "value")
 	if err != nil {
 		err = errors.Join(err, fmt.Errorf("failed to extract kubeconfig from secret %s", kubeconfigSecret.Name))
 		return nil, err

--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller_test.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller_test.go
@@ -34,6 +34,7 @@ import (
 
 	controlplanev1alpha2 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
 	testutils "github.com/openshift-assisted/cluster-api-agent/test/utils"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -273,6 +274,123 @@ var _ = Describe("OpenshiftAssistedControlPlane Controller", func() {
 	})
 })
 
+var _ = Describe("Upgrade", func() {
+	Context("distributionVersion returned", func() {
+		const (
+			openshiftAssistedControlPlaneName = "test-resource"
+			clusterName                       = "test-cluster"
+			namespace                         = "test"
+		)
+		var (
+			ctx                         = context.Background()
+			cluster                     *clusterv1.Cluster
+			controllerReconciler        *OpenshiftAssistedControlPlaneReconciler
+			mockCtrl                    *gomock.Controller
+			k8sClient                   client.Client
+			mockWorkloadClientGenerator *mockWorkloadClient
+		)
+		BeforeEach(func() {
+			k8sClient = fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithStatusSubresource(&controlplanev1alpha2.OpenshiftAssistedControlPlane{}).Build()
+
+			mockCtrl = gomock.NewController(GinkgoT())
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+			mockWorkloadClientGenerator = NewMockWorkloadClient()
+			controllerReconciler = &OpenshiftAssistedControlPlaneReconciler{
+				Client:                         k8sClient,
+				Scheme:                         k8sClient.Scheme(),
+				OpenShiftVersion:               &mockOpenShiftVersioner{},
+				WorkloadClusterClientGenerator: mockWorkloadClientGenerator,
+			}
+
+			By("creating a cluster")
+			cluster = &clusterv1.Cluster{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, cluster)
+			if err != nil && errors.IsNotFound(err) {
+				cluster = testutils.NewCluster(clusterName, namespace)
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
+			k8sClient = nil
+		})
+		When("the kubeconfig secret is not yet available for the workload cluster", func() {
+			It("should return an error and the distribution version should be empty", func() {
+				By("creating the openshiftassistedcontrolplane with condition kubeconfig available set to false")
+				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
+				conditions.MarkFalse(
+					openshiftAssistedControlPlane,
+					controlplanev1alpha2.KubeconfigAvailableCondition,
+					controlplanev1alpha2.KubeconfigUnavailableFailedReason,
+					clusterv1.ConditionSeverityInfo,
+					"error retrieving Kubeconfig %v", fmt.Errorf("secret does not exist"),
+				)
+
+				By("confirming an error is returned when calling getWorkloadClusterVersion")
+				_, err := controllerReconciler.getWorkloadClusterVersion(ctx, openshiftAssistedControlPlane)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("kubeconfig for workload cluster is not available yet"))
+			})
+		})
+
+		When("the kubeconfig secret is available", func() {
+			It("should return the openshiftassistedcontrolplane's distributionversion", func() {
+				By("creating the openshiftassistedcontrolplane with condition kubeconfig available set to true")
+				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
+				openshiftAssistedControlPlane.Labels = map[string]string{
+					clusterv1.ClusterNameLabel: cluster.Name,
+				}
+				conditions.MarkTrue(openshiftAssistedControlPlane, controlplanev1alpha2.KubeconfigAvailableCondition)
+				By("creating the kubeconfig secret")
+				kubeconfigSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-kubeconfig", cluster.Name),
+						Namespace: openshiftAssistedControlPlane.Namespace,
+					},
+					Data: map[string][]byte{
+						"value": []byte("kubeconfig"),
+					},
+				}
+				Expect(k8sClient.Create(ctx, kubeconfigSecret)).To(Succeed())
+				By("creating a cluster version using the workload cluster's client")
+				mockWorkloadClientGenerator.MockCreateClusterVersion(openshiftAssistedControlPlane.Spec.DistributionVersion)
+				By("checking the cluster version returned")
+				distributionVersion, err := controllerReconciler.getWorkloadClusterVersion(ctx, openshiftAssistedControlPlane)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(distributionVersion).To(Equal(openshiftAssistedControlPlane.Spec.DistributionVersion))
+			})
+		})
+	})
+	Context("isUpgradeRequested", func() {
+		When("openshiftassistedcontrolplane doesn't have the distributionVersion status set", func() {
+			It("returns false", func() {
+				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
+				Expect(isUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
+			})
+		})
+		When("openshiftassistedcontrolplane's requested upgrade is less than the current workload cluster's version", func() {
+			It("returns false", func() {
+				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
+				openshiftAssistedControlPlane.Status.DistributionVersion = "4.18.0"
+				Expect(isUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
+			})
+		})
+		When("openshiftassistedcontrolplane's requested upgrade is greater than the current workload cluster's version", func() {
+			It("returns true", func() {
+				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
+				openshiftAssistedControlPlane.Status.DistributionVersion = "4.11.0"
+				Expect(isUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeTrue())
+			})
+		})
+	})
+})
+
 func checkReadyConditions(expectedReadyConditions []clusterv1.ConditionType, openshiftAssistedControlPlane *controlplanev1alpha2.OpenshiftAssistedControlPlane) {
 	for _, conditionType := range expectedReadyConditions {
 		By(fmt.Sprintf("checking condition %s ready", conditionType))
@@ -294,4 +412,35 @@ func getOpenshiftAssistedControlPlane() *controlplanev1alpha2.OpenshiftAssistedC
 			DistributionVersion: "4.16.0",
 		},
 	}
+}
+
+type mockWorkloadClient struct {
+	mockClient client.Client
+}
+
+func NewMockWorkloadClient() *mockWorkloadClient {
+	workloadK8sClient := fakeclient.NewClientBuilder().
+		WithScheme(testScheme).Build()
+	return &mockWorkloadClient{
+		mockClient: workloadK8sClient,
+	}
+}
+
+func (m *mockWorkloadClient) GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error) {
+
+	return m.mockClient, nil
+}
+
+func (m *mockWorkloadClient) MockCreateClusterVersion(version string) {
+	clusterVersion := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Release{
+				Version: version,
+			},
+		},
+	}
+	Expect(m.mockClient.Create(context.Background(), clusterVersion)).To(Succeed())
 }

--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller_test.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller_test.go
@@ -333,7 +333,8 @@ var _ = Describe("Upgrade", func() {
 				)
 
 				By("confirming an error is returned when calling getWorkloadClusterVersion")
-				_, err := controllerReconciler.getWorkloadClusterVersion(ctx, openshiftAssistedControlPlane)
+				_, err := GetWorkloadClusterVersion(ctx, controllerReconciler.Client,
+					controllerReconciler.WorkloadClusterClientGenerator, openshiftAssistedControlPlane)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("kubeconfig for workload cluster is not available yet"))
 			})
@@ -361,31 +362,32 @@ var _ = Describe("Upgrade", func() {
 				By("creating a cluster version using the workload cluster's client")
 				mockWorkloadClientGenerator.MockCreateClusterVersion(openshiftAssistedControlPlane.Spec.DistributionVersion)
 				By("checking the cluster version returned")
-				distributionVersion, err := controllerReconciler.getWorkloadClusterVersion(ctx, openshiftAssistedControlPlane)
+				distributionVersion, err := GetWorkloadClusterVersion(ctx, controllerReconciler.Client,
+					controllerReconciler.WorkloadClusterClientGenerator, openshiftAssistedControlPlane)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(distributionVersion).To(Equal(openshiftAssistedControlPlane.Spec.DistributionVersion))
 			})
 		})
 	})
-	Context("isUpgradeRequested", func() {
+	Context("IsUpgradeRequested", func() {
 		When("openshiftassistedcontrolplane doesn't have the distributionVersion status set", func() {
 			It("returns false", func() {
 				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
-				Expect(isUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
+				Expect(IsUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
 			})
 		})
 		When("openshiftassistedcontrolplane's requested upgrade is less than the current workload cluster's version", func() {
 			It("returns false", func() {
 				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
 				openshiftAssistedControlPlane.Status.DistributionVersion = "4.18.0"
-				Expect(isUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
+				Expect(IsUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
 			})
 		})
 		When("openshiftassistedcontrolplane's requested upgrade is greater than the current workload cluster's version", func() {
 			It("returns true", func() {
 				openshiftAssistedControlPlane := getOpenshiftAssistedControlPlane()
 				openshiftAssistedControlPlane.Status.DistributionVersion = "4.11.0"
-				Expect(isUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeTrue())
+				Expect(IsUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeTrue())
 			})
 		})
 	})
@@ -427,7 +429,6 @@ func NewMockWorkloadClient() *mockWorkloadClient {
 }
 
 func (m *mockWorkloadClient) GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error) {
-
 	return m.mockClient, nil
 }
 

--- a/controlplane/internal/controller/suite_test.go
+++ b/controlplane/internal/controller/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	controlplanev1alpha1 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
+	configv1 "github.com/openshift/api/config/v1"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +55,7 @@ var _ = BeforeSuite(func() {
 
 	utilruntime.Must(controlplanev1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(corev1.AddToScheme(testScheme))
+	utilruntime.Must(configv1.AddToScheme(testScheme))
 	utilruntime.Must(clusterv1.AddToScheme(testScheme))
 	utilruntime.Must(hivev1.AddToScheme(testScheme))
 	utilruntime.Must(hiveext.AddToScheme(testScheme))

--- a/controlplane/internal/upgrade/upgrade.go
+++ b/controlplane/internal/upgrade/upgrade.go
@@ -1,0 +1,105 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	controlplanev1alpha2 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
+	"github.com/openshift-assisted/cluster-api-agent/controlplane/internal/workloadclient"
+	"github.com/openshift-assisted/cluster-api-agent/util"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/coreos/go-semver/semver"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsUpgradeRequested(ctx context.Context, oacp *controlplanev1alpha2.OpenshiftAssistedControlPlane) bool {
+	log := ctrl.LoggerFrom(ctx)
+	oacpDistVersion, err := semver.NewVersion(oacp.Spec.DistributionVersion)
+	if err != nil {
+		log.Error(err, "failed to detect OpenShift version from ACP spec", "version", oacp.Spec.DistributionVersion)
+		return false
+	}
+
+	upgrade := false
+	if oacp.Status.DistributionVersion == "" {
+		return false
+	}
+	currentOACPDistVersion, err := semver.NewVersion(oacp.Status.DistributionVersion)
+	if err != nil {
+		log.Error(err, "failed to detect OpenShift version from ACP status", "version", oacp.Spec.DistributionVersion)
+		return false
+	}
+
+	if oacpDistVersion.Compare(*currentOACPDistVersion) > 0 {
+		log.Info("Upgrade detected, new requested version is greater than current version",
+			"new requested version", oacpDistVersion.String(), "current version", currentOACPDistVersion.String())
+		upgrade = true
+	}
+	return upgrade
+}
+
+func GetWorkloadClusterVersion(ctx context.Context, client client.Client,
+	workloadClusterClientGenerator workloadclient.ClientGenerator,
+	oacp *controlplanev1alpha2.OpenshiftAssistedControlPlane) (string, error) {
+	workloadClient, err := getWorkloadClient(ctx, client, workloadClusterClientGenerator, oacp)
+	if err != nil {
+		return "", err
+	}
+
+	var clusterVersion configv1.ClusterVersion
+	if err := workloadClient.Get(ctx, types.NamespacedName{Name: "version"}, &clusterVersion); err != nil {
+		err = errors.Join(err, fmt.Errorf(("failed to get ClusterVersion from workload cluster")))
+		return "", err
+	}
+
+	return clusterVersion.Status.Desired.Version, nil
+}
+
+func getWorkloadClient(ctx context.Context, client client.Client,
+	workloadClusterClientGenerator workloadclient.ClientGenerator,
+	oacp *controlplanev1alpha2.OpenshiftAssistedControlPlane) (client.Client, error) {
+	if !isKubeconfigAvailable(oacp) {
+		return nil, fmt.Errorf("kubeconfig for workload cluster is not available yet")
+	}
+
+	kubeconfigSecret, err := util.GetClusterKubeconfigSecret(ctx, client, oacp.Labels[clusterv1.ClusterNameLabel], oacp.Namespace)
+	if err != nil {
+		err = errors.Join(err, fmt.Errorf("failed to get cluster kubeconfig secret"))
+		return nil, err
+	}
+
+	if kubeconfigSecret == nil {
+		return nil, fmt.Errorf("kubeconfig secret was not found")
+	}
+
+	kubeconfig, err := util.ExtractKubeconfigFromSecret(kubeconfigSecret, "value")
+	if err != nil {
+		err = errors.Join(err, fmt.Errorf("failed to extract kubeconfig from secret %s", kubeconfigSecret.Name))
+		return nil, err
+	}
+
+	workloadClient, err := workloadClusterClientGenerator.GetWorkloadClusterClient(kubeconfig)
+	if err != nil {
+		err = errors.Join(err, fmt.Errorf("failed to establish client for workload cluster from kubeconfig"))
+		return nil, err
+	}
+	return workloadClient, nil
+}
+
+// isKubeconfigAvailable returns true if the openshift assisted control plane
+// condition KubeconfigAvailable is true
+func isKubeconfigAvailable(oacp *controlplanev1alpha2.OpenshiftAssistedControlPlane) bool {
+	kubeconfigFoundCondition := util.FindStatusCondition(oacp.Status.Conditions, controlplanev1alpha2.KubeconfigAvailableCondition)
+	if kubeconfigFoundCondition == nil {
+		return false
+	}
+	return kubeconfigFoundCondition.Status == corev1.ConditionTrue
+}

--- a/controlplane/internal/upgrade/upgrade_test.go
+++ b/controlplane/internal/upgrade/upgrade_test.go
@@ -1,0 +1,193 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	controlplanev1alpha2 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
+	testutils "github.com/openshift-assisted/cluster-api-agent/test/utils"
+
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Upgrade")
+}
+
+var testScheme = runtime.NewScheme()
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+
+	utilruntime.Must(controlplanev1alpha2.AddToScheme(testScheme))
+	utilruntime.Must(corev1.AddToScheme(testScheme))
+	utilruntime.Must(configv1.AddToScheme(testScheme))
+	utilruntime.Must(clusterv1.AddToScheme(testScheme))
+	//+kubebuilder:scaffold:scheme
+
+})
+
+var _ = Describe("Upgrade", func() {
+	const (
+		openshiftAssistedControlPlaneName = "test-resource"
+		clusterName                       = "test-cluster"
+		namespace                         = "test"
+	)
+	var (
+		ctx     = context.Background()
+		cluster *clusterv1.Cluster
+
+		mockCtrl                    *gomock.Controller
+		k8sClient                   client.Client
+		mockWorkloadClientGenerator *mockWorkloadClient
+	)
+	BeforeEach(func() {
+		k8sClient = fakeclient.NewClientBuilder().
+			WithScheme(testScheme).
+			WithStatusSubresource(&controlplanev1alpha2.OpenshiftAssistedControlPlane{}).Build()
+
+		mockCtrl = gomock.NewController(GinkgoT())
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		mockWorkloadClientGenerator = NewMockWorkloadClient()
+
+		By("creating a cluster")
+		cluster = &clusterv1.Cluster{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, cluster)
+		if err != nil && errors.IsNotFound(err) {
+			cluster = testutils.NewCluster(clusterName, namespace)
+			err := k8sClient.Create(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+		k8sClient = nil
+	})
+	Context("GetWorkloadClusterVersion", func() {
+		When("the kubeconfig secret is not yet available for the workload cluster", func() {
+			It("should return an error and the distribution version should be empty", func() {
+				By("creating the openshiftassistedcontrolplane with condition kubeconfig available set to false")
+				openshiftAssistedControlPlane := testutils.NewOpenshiftAssistedControlPlane(namespace, openshiftAssistedControlPlaneName)
+				conditions.MarkFalse(
+					openshiftAssistedControlPlane,
+					controlplanev1alpha2.KubeconfigAvailableCondition,
+					controlplanev1alpha2.KubeconfigUnavailableFailedReason,
+					clusterv1.ConditionSeverityInfo,
+					"error retrieving Kubeconfig %v", fmt.Errorf("secret does not exist"),
+				)
+
+				By("confirming an error is returned when calling getWorkloadClusterVersion")
+				_, err := GetWorkloadClusterVersion(ctx, k8sClient,
+					mockWorkloadClientGenerator, openshiftAssistedControlPlane)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("kubeconfig for workload cluster is not available yet"))
+			})
+		})
+
+		When("the kubeconfig secret is available", func() {
+			It("should return the openshiftassistedcontrolplane's distributionversion", func() {
+				By("creating the openshiftassistedcontrolplane with condition kubeconfig available set to true")
+				openshiftAssistedControlPlane := testutils.NewOpenshiftAssistedControlPlane(namespace, openshiftAssistedControlPlaneName)
+				openshiftAssistedControlPlane.Labels = map[string]string{
+					clusterv1.ClusterNameLabel: cluster.Name,
+				}
+				conditions.MarkTrue(openshiftAssistedControlPlane, controlplanev1alpha2.KubeconfigAvailableCondition)
+				By("creating the kubeconfig secret")
+				kubeconfigSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-kubeconfig", cluster.Name),
+						Namespace: openshiftAssistedControlPlane.Namespace,
+					},
+					Data: map[string][]byte{
+						"value": []byte("kubeconfig"),
+					},
+				}
+				Expect(k8sClient.Create(ctx, kubeconfigSecret)).To(Succeed())
+				By("creating a cluster version using the workload cluster's client")
+				mockWorkloadClientGenerator.MockCreateClusterVersion(openshiftAssistedControlPlane.Spec.DistributionVersion)
+				By("checking the cluster version returned")
+				distributionVersion, err := GetWorkloadClusterVersion(ctx, k8sClient,
+					mockWorkloadClientGenerator, openshiftAssistedControlPlane)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(distributionVersion).To(Equal(openshiftAssistedControlPlane.Spec.DistributionVersion))
+			})
+		})
+	})
+	Context("IsUpgradeRequested", func() {
+		When("openshiftassistedcontrolplane doesn't have the distributionVersion status set", func() {
+			It("returns false", func() {
+				openshiftAssistedControlPlane := testutils.NewOpenshiftAssistedControlPlane(namespace, openshiftAssistedControlPlaneName)
+				Expect(IsUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
+			})
+		})
+		When("openshiftassistedcontrolplane's requested upgrade is less than the current workload cluster's version", func() {
+			It("returns false", func() {
+				openshiftAssistedControlPlane := testutils.NewOpenshiftAssistedControlPlane(namespace, openshiftAssistedControlPlaneName)
+				openshiftAssistedControlPlane.Status.DistributionVersion = "4.18.0"
+				Expect(IsUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeFalse())
+			})
+		})
+		When("openshiftassistedcontrolplane's requested upgrade is greater than the current workload cluster's version", func() {
+			It("returns true", func() {
+				openshiftAssistedControlPlane := testutils.NewOpenshiftAssistedControlPlane(namespace, openshiftAssistedControlPlaneName)
+				openshiftAssistedControlPlane.Status.DistributionVersion = "4.11.0"
+				Expect(IsUpgradeRequested(context.Background(), openshiftAssistedControlPlane)).To(BeTrue())
+			})
+		})
+	})
+})
+
+type mockWorkloadClient struct {
+	mockClient client.Client
+}
+
+func NewMockWorkloadClient() *mockWorkloadClient {
+	workloadK8sClient := fakeclient.NewClientBuilder().
+		WithScheme(testScheme).Build()
+	return &mockWorkloadClient{
+		mockClient: workloadK8sClient,
+	}
+}
+
+func (m *mockWorkloadClient) GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error) {
+	return m.mockClient, nil
+}
+
+func (m *mockWorkloadClient) MockCreateClusterVersion(version string) {
+	clusterVersion := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Release{
+				Version: version,
+			},
+		},
+	}
+	Expect(m.mockClient.Create(context.Background(), clusterVersion)).To(Succeed())
+}

--- a/controlplane/internal/workloadclient/workload_client.go
+++ b/controlplane/internal/workloadclient/workload_client.go
@@ -8,7 +8,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error) {
+type WorkloadClusterClientGenerator struct{}
+
+type ClientGenerator interface {
+	GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error)
+}
+
+func NewWorkloadClusterClientGenerator() *WorkloadClusterClientGenerator {
+	return &WorkloadClusterClientGenerator{}
+}
+
+func (w *WorkloadClusterClientGenerator) GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error) {
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get clientconfig from kubeconfig data")

--- a/controlplane/internal/workloadclient/workload_client.go
+++ b/controlplane/internal/workloadclient/workload_client.go
@@ -1,0 +1,31 @@
+package workloadclient
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetWorkloadClusterClient(kubeconfig []byte) (client.Client, error) {
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get clientconfig from kubeconfig data")
+	}
+
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get restconfig for kube client")
+	}
+
+	schemes := runtime.NewScheme()
+	if err := configv1.Install(schemes); err != nil {
+		return nil, err
+	}
+	targetClient, err := client.New(restConfig, client.Options{Scheme: schemes})
+	if err != nil {
+		return nil, err
+	}
+	return targetClient, nil
+}

--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/openshift-assisted/cluster-api-agent/controlplane/internal/version"
+	"github.com/openshift-assisted/cluster-api-agent/controlplane/internal/workloadclient"
 
 	bootstrapv1alpha1 "github.com/openshift-assisted/cluster-api-agent/bootstrap/api/v1alpha1"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
@@ -133,9 +134,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controlplanecontroller.OpenshiftAssistedControlPlaneReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		OpenShiftVersion: version.NewOpenShiftVersion(mgr.GetClient()),
+		Client:                         mgr.GetClient(),
+		Scheme:                         mgr.GetScheme(),
+		OpenShiftVersion:               version.NewOpenShiftVersion(mgr.GetClient()),
+		WorkloadClusterClientGenerator: workloadclient.NewWorkloadClusterClientGenerator(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenshiftAssistedControlPlane")
 		os.Exit(1)

--- a/util/util.go
+++ b/util/util.go
@@ -125,8 +125,8 @@ func GetClusterKubeconfigSecret(
 }
 
 // ExtractKubeconfigFromSecret takes a kubernetes secret and returns the kubeconfig
-func ExtractKubeconfigFromSecret(kubeconfigSecret *corev1.Secret) ([]byte, error) {
-	kubeconfig, ok := kubeconfigSecret.Data["kubeconfig"]
+func ExtractKubeconfigFromSecret(kubeconfigSecret *corev1.Secret, dataKey string) ([]byte, error) {
+	kubeconfig, ok := kubeconfigSecret.Data[dataKey]
 	if !ok {
 		return nil, errors.New("kubeconfig not found in secret")
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -111,6 +111,19 @@ func getK8sVersionFromImageStream(is imageapi.ImageStream) (string, error) {
 	return "", fmt.Errorf("unable to find kubernetes version")
 }
 
+func GetClusterKubeconfigSecret(
+	ctx context.Context,
+	client client.Client,
+	clusterName, namespace string,
+) (*corev1.Secret, error) {
+	secretName := fmt.Sprintf("%s-kubeconfig", clusterName)
+	kubeconfigSecret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, kubeconfigSecret); err != nil {
+		return nil, err
+	}
+	return kubeconfigSecret, nil
+}
+
 // ExtractKubeconfigFromSecret takes a kubernetes secret and returns the kubeconfig
 func ExtractKubeconfigFromSecret(kubeconfigSecret *corev1.Secret) ([]byte, error) {
 	kubeconfig, ok := kubeconfigSecret.Data["kubeconfig"]

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 	controlplanev1alpha1 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
 	logutil "github.com/openshift-assisted/cluster-api-agent/util/log"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/labels/format"
@@ -107,4 +109,13 @@ func getK8sVersionFromImageStream(is imageapi.ImageStream) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("unable to find kubernetes version")
+}
+
+// ExtractKubeconfigFromSecret takes a kubernetes secret and returns the kubeconfig
+func ExtractKubeconfigFromSecret(kubeconfigSecret *corev1.Secret) ([]byte, error) {
+	kubeconfig, ok := kubeconfigSecret.Data["kubeconfig"]
+	if !ok {
+		return nil, errors.New("kubeconfig not found in secret")
+	}
+	return kubeconfig, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -119,3 +119,13 @@ func ExtractKubeconfigFromSecret(kubeconfigSecret *corev1.Secret) ([]byte, error
 	}
 	return kubeconfig, nil
 }
+
+// FindStatusCondition takes a set of conditions and a condition to find and returns it if it exists
+func FindStatusCondition(conditions clusterv1.Conditions, conditionToFind clusterv1.ConditionType) *clusterv1.Condition {
+	for _, condition := range conditions {
+		if condition.Type == conditionToFind {
+			return &condition
+		}
+	}
+	return nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -134,7 +134,8 @@ func ExtractKubeconfigFromSecret(kubeconfigSecret *corev1.Secret, dataKey string
 }
 
 // FindStatusCondition takes a set of conditions and a condition to find and returns it if it exists
-func FindStatusCondition(conditions clusterv1.Conditions, conditionToFind clusterv1.ConditionType) *clusterv1.Condition {
+func FindStatusCondition(conditions clusterv1.Conditions,
+	conditionToFind clusterv1.ConditionType) *clusterv1.Condition {
 	for _, condition := range conditions {
 		if condition.Type == conditionToFind {
 			return &condition


### PR DESCRIPTION
Adds the status field `distributionVersion` which is set to the OCP version in the workload cluster's cluster version when the workload cluster is installed. 

Determines if an upgrade is requested by comparing the `distributionVersion` spec field to the `distributionVersion` status field.

Supersedes https://github.com/openshift-assisted/cluster-api-agent/pull/78