### PR TITLE
MGMT-19877: Trigger workload cluster upgrade

### DIFF
--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
@@ -190,8 +190,11 @@ func (r *OpenshiftAssistedControlPlaneReconciler) Reconcile(ctx context.Context,
 	}
 
 	if upgrade.IsUpgradeRequested(ctx, oacp) {
-		//TODO: Handle upgrade request
-		log.Info("upgrade for control plane has been requested")
+		log.Info("workload cluster upgrade has been requested, starting upgrade", "current workload cluster version", oacp.Status.DistributionVersion, "new workload cluster version", oacp.Spec.DistributionVersion)
+		if err := upgrade.UpgradeWorkloadCluster(ctx, r.Client, r.WorkloadClusterClientGenerator, oacp); err != nil {
+			log.Error(err, "failed to upgrade workload cluster")
+		}
+		log.Info("workload cluster upgrade set on ClusterVersion, waiting completion")
 	}
 	return ctrl.Result{}, r.reconcileReplicas(ctx, oacp, cluster)
 }


### PR DESCRIPTION
Modifies the cluster version of the workload cluster when an upgrade is requested to have CVO upgrade the workload cluster.

/cc @rccrdpccl 

---
To upgrade an installed workload cluster:

1. Edit `openshiftassistedcontrolplane` and change `spec.distributionVersion` to a newer version

**Example:**

Original:
````sh
kubectl edit openshiftassistedcontrolplane -n test-capi
````
````yaml
  spec:
    distributionVersion: 4.19.0-0.nightly-2025-02-11-035912
````
Updated:
````yaml
  spec:
    distributionVersion: 4.19.0-0.nightly-2025-02-11-161912
````

2. [For testing with non-GA openshift versions] Add annotation to specify the release image with digest in the `openshiftassistedcontrolplane`

````yaml
  kind: OpenshiftAssistedControlPlane
  metadata:
    annotations:
      cluster.x-k8s.io/upgrade-image-override: registry.ci.openshift.org/ocp/release@sha256:a1910b2c91db6b0aa6ef37471f55ed20440caf22c05b7401600c30017c5500ea
````

3. Verify by getting the kubeconfig for the workload cluster and checking that `ClusterVerison` is upgrading
```sh
kubectl get secret -n test-capi test-multinode-admin-kubeconfig -ojsonpath='{.data.kubeconfig}' | base64 -d > /tmp/workload-kubeconfig

kubectl get --kubeconfig /tmp/workload-kubeconfig clusterversion -oyaml
```

`ClusterVersion` should have the `desiredUpdate` field set 
```yaml
  kind: ClusterVersion
  metadata:
    name: version
  spec:
    desiredUpdate:
      architecture: ""
      force: true
      image: registry.ci.openshift.org/ocp/release@sha256:a1910b2c91db6b0aa6ef37471f55ed20440caf22c05b7401600c30017c5500ea
```

`ClusterVersion` should also show progressing to the desired version
```sh
kubectl get --kubeconfig /tmp/workload-kubeconfig clusterversion
```

----
The annotation
```
cluster.x-k8s.io/upgrade-image-override
```
Is added because we're using a non-GA version of openshift for testing. If we simply specify the version with a non-GA version like the nightlies, CVO will complain with
```
    - lastTransitionTime: "2025-02-12T16:45:52Z"
      message: 'The cluster version is invalid: spec.desiredUpdate.version: Invalid
        value: "4.19.0-0.nightly-2025-02-11-035912": when image is empty the update
        must be an available update'
```
We also want the image override used to be in digest format, otherwise CVO will complain with
```
    - lastTransitionTime: "2025-02-12T00:37:23Z"
      message: 'Retrieving payload failed version="4.19.0-0.nightly-2025-02-11-035912"
        image="registry.ci.openshift.org/ocp/release:4.19.0-0.nightly-2025-02-11-035912"
        failure=The update cannot be verified: release images that are not accessed
        via digest cannot be verified'
      reason: RetrievePayload
      status: "False"
```
And when we set the image override, we also set `force` to `true` in `ClusterVersion`'s `desiredUpdate` field because of the checks CVO runs which will complain with
```
      message: 'Retrieving payload failed version="4.19.0-0.nightly-2025-02-11-035912"
        image="registry.ci.openshift.org/ocp/release@sha256:8f15efe5fa83eac0244721d7c5274589878c8dc2ac188128af2af1a8fb6000d1"
        failure=The update cannot be verified: unable to verify sha256:8f15efe5fa83eac0244721d7c5274589878c8dc2ac188128af2af1a8fb6000d1
        against keyrings: verifier-public-key-redhat'
```