### PR TITLE
MGMT-20102: Set clusterinstallref on clusterdeployment create

### DIFF
--- a/assistedinstaller/clusterdeployment.go
+++ b/assistedinstaller/clusterdeployment.go
@@ -3,6 +3,7 @@ package assistedinstaller
 import (
 	"github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
 	"github.com/openshift-assisted/cluster-api-agent/util"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/apis/hive/v1/agent"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,13 @@ func GetClusterDeploymentFromConfig(
 		},
 		Spec: hivev1.ClusterDeploymentSpec{
 			ClusterName: assistedClusterName,
-			BaseDomain:  acp.Spec.Config.BaseDomain,
+			ClusterInstallRef: &hivev1.ClusterInstallLocalReference{
+				Group:   hiveext.Group,
+				Version: hiveext.Version,
+				Kind:    "AgentClusterInstall",
+				Name:    acp.Name,
+			},
+			BaseDomain: acp.Spec.Config.BaseDomain,
 			Platform: hivev1.Platform{
 				AgentBareMetal: &agent.BareMetalPlatform{},
 			},

--- a/controlplane/internal/controller/clusterdeployment_controller.go
+++ b/controlplane/internal/controller/clusterdeployment_controller.go
@@ -75,21 +75,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	log.WithValues("openshiftassisted_control_plane", acp.Name, "openshiftassisted_control_plane_namespace", acp.Namespace)
 
-	if clusterDeployment.Spec.ClusterInstallRef != nil && r.agentClusterInstallExists(ctx, clusterDeployment.Spec.ClusterInstallRef.Name, clusterDeployment.Namespace) {
-		log.V(logutil.TraceLevel).Info(
-			"skipping reconciliation: cluster deployment already has a referenced agent cluster install",
-			"agent_cluster_install", clusterDeployment.Spec.ClusterInstallRef.Name,
-		)
-		return ctrl.Result{}, nil
-	}
-
 	return r.ensureAgentClusterInstall(ctx, clusterDeployment, acp)
-}
-
-func (r *ClusterDeploymentReconciler) agentClusterInstallExists(ctx context.Context, agentClusterInstallName, namespace string) bool {
-	agentclusterinstall := &hiveext.AgentClusterInstall{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: agentClusterInstallName, Namespace: namespace}, agentclusterinstall)
-	return err != nil
 }
 
 func (r *ClusterDeploymentReconciler) ensureAgentClusterInstall(


### PR DESCRIPTION
This is required to pass a hive webhook check which assumes either provisioning or clusterinstallref must be set.

Before this change we were seeing errors like the following when hive was also installed on the hub cluster:

```
2025-02-28T15:02:14Z	INFO	Finished reconciling OpenshiftAssistedControlPlane	{"controller": "openshiftassistedcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "OpenshiftAssistedControlPlane", "OpenshiftAssistedControlPlane": {"name":"test-multinode","namespace":"test-capi"}, "namespace": "test-capi", "name": "test-multinode", "reconcileID": "a539b52d-944b-4051-a50b-00cfc20168bf"}
2025-02-28T15:02:14Z	ERROR	Reconciler error	{"controller": "openshiftassistedcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "OpenshiftAssistedControlPlane", "OpenshiftAssistedControlPlane": {"name":"test-multinode","namespace":"test-capi"}, "namespace": "test-capi", "name": "test-multinode", "reconcileID": "a539b52d-944b-4051-a50b-00cfc20168bf", "error": "admission webhook \"clusterdeploymentvalidators.admission.hive.openshift.io\" denied the request: ClusterDeployment.hive.openshift.io \"test-multinode\" is invalid: spec.provisioning: Required value: provisioning is required if not installed"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227
```

Changing this also requires us to remove the check for ACI and ClusterInstallRef when reconciling ClusterDeployment

This was preventing the creation of the agent cluster install when the ClusterDeployment was created with the ClusterInstallRef already in place.

Additionally the logic for `agentClusterInstallExists` was incorrect (it should have returned true only when the error was nil and probably also should have been checking the error type specifically for not found).
But also there is no reason to not ensure the ACI is correct even when it already exists - `ensureAgentClusterInstall` should be idempotent.

Resolves https://issues.redhat.com/browse/MGMT-20102