### PR TITLE
NO-ISSUE: Explicitly set namespace in all multi-node example resources

### DIFF
--- a/examples/multi-node-example.yaml
+++ b/examples/multi-node-example.yaml
@@ -131,6 +131,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: test-multinode-worker
+  namespace: test-capi
   labels:
     cluster.x-k8s.io/cluster-name: test-multinode
 spec:
@@ -159,6 +160,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OpenshiftAssistedConfigTemplate
 metadata:
   name: test-multinode-worker
+  namespace: test-capi
   labels:
     cluster.x-k8s.io/cluster-name: test-multinode
 spec:


### PR DESCRIPTION
When deploying this I was mistakenly in another namespace and the cluster install failed because the MachineDeployment and OpenshiftAssistedConfigTemplate were in the wrong namespace.