### PR TITLE
MGMT-20105: Add rbac for managedclustersets/join

### DIFF
--- a/controlplane-components.yaml
+++ b/controlplane-components.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
-    cluster.x-k8s.io/v1beta1: v1alpha1
+    cluster.x-k8s.io/v1beta1: v1alpha2
   name: openshiftassistedcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
   group: controlplane.cluster.x-k8s.io
@@ -70,10 +70,10 @@ spec:
       name: Age
       type: date
     - description: OpenShift version associated with this control plane
-      jsonPath: .spec.version
-      name: Version
+      jsonPath: .spec.distributionVersion
+      name: Distribution Version
       type: string
-    name: v1alpha1
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: OpenshiftAssistedControlPlane is the Schema for the openshiftassistedcontrolplane
@@ -221,16 +221,17 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
-                  releaseImage:
-                    type: string
                   sshAuthorizedKey:
                     description: SSHAuthorizedKey ssh key for accessing the cluster
                       nodes after reboot
                     type: string
                 required:
                 - baseDomain
-                - releaseImage
                 type: object
+              distributionVersion:
+                description: DistributionVersion describes the targeted OpenShift
+                  version
+                type: string
               machineTemplate:
                 properties:
                   infrastructureRef:
@@ -418,6 +419,19 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
+                  nodeRegistration:
+                    description: NodeRegistrationOption holds fields related to registering
+                      nodes to the cluster
+                    properties:
+                      kubeletExtraLabels:
+                        description: KubeletExtraLabels passes extra labels to kubelet.
+                        items:
+                          type: string
+                        type: array
+                      name:
+                        description: Defaults to the hostname of the node if not provided.
+                        type: string
+                    type: object
                   osImageVersion:
                     description: |-
                       OSImageVersion is the version of OS image to use when generating the InfraEnv.
@@ -463,11 +477,9 @@ spec:
               replicas:
                 format: int32
                 type: integer
-              version:
-                type: string
             required:
+            - distributionVersion
             - machineTemplate
-            - version
             type: object
           status:
             description: OpenshiftAssistedControlPlaneStatus defines the observed
@@ -563,6 +575,11 @@ spec:
                   - type
                   type: object
                 type: array
+              distributionVersion:
+                description: |-
+                  DistributionVersion represents the current OpenShift version installed on the
+                  control plane machines in the cluster.
+                type: string
               failureMessage:
                 description: |-
                   ErrorMessage indicates that there is a terminal problem reconciling the
@@ -731,6 +748,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/controlplane/config/rbac/role.yaml
+++ b/controlplane/config/rbac/role.yaml
@@ -40,6 +40,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters

--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
@@ -94,6 +94,7 @@ var minVersion = semver.MustParse(minOpenShiftVersion)
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=openshiftassistedcontrolplanes/finalizers,verbs=update
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=list
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclustersets/join,verbs=create
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
This prevents the following webhook failure from ACM when creating the cluster deployment

```
2025-02-28T15:30:35Z	ERROR	failed to ensure a ClusterDeployment exists	{"controller": "openshiftassistedcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "OpenshiftAssistedControlPlane", "OpenshiftAssistedControlPlane": {"name":"test-multinode","namespace":"test-capi"}, "namespace": "test-capi", "name": "test-multinode", "reconcileID": "4d1476d6-cb0d-45e5-b704-a12480d5da2b", "error": "admission webhook \"ocm.validating.webhook.admission.open-cluster-management.io\" denied the request: user \"system:serviceaccount:capi-agent-controlplane-system:capi-agent-controlplanecontroller-manager\" cannot add/remove the resource to/from ManagedClusterSet \"\""}
github.com/openshift-assisted/cluster-api-agent/controlplane/internal/controller.(*OpenshiftAssistedControlPlaneReconciler).Reconcile
	/workspace/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go:181
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227
```

Resolves https://issues.redhat.com/browse/MGMT-20105