### PR TITLE
bugfix: unavailable machines should not be negative

### DIFF
--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
@@ -544,7 +544,7 @@ func (r *OpenshiftAssistedControlPlaneReconciler) updateReplicaStatus(ctx contex
 	}
 
 	acp.Status.Replicas = int32(machines.Len())
-	acp.Status.UnavailableReplicas = desiredReplicas - int32(readyMachines)
+	acp.Status.UnavailableReplicas = acp.Status.Replicas - int32(readyMachines)
 	acp.Status.ReadyReplicas = int32(readyMachines)
 	if acp.Status.ReadyReplicas == desiredReplicas {
 		conditions.MarkTrue(acp, controlplanev1alpha2.MachinesCreatedCondition)


### PR DESCRIPTION
Unavailable Replicas should be total machines - ready machines:
When scaling down, desired replicas are less than actual machines: desired machines - ready machines would be negative