### PR TITLE
MGMT-20162: improve usage of CreateOrUpdate

### DIFF
--- a/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
+++ b/controlplane/internal/controller/openshiftassistedcontrolplane_controller.go
@@ -445,7 +445,7 @@ func (r *OpenshiftAssistedControlPlaneReconciler) ensureClusterDeployment(
 	if acp.Status.ClusterDeploymentRef == nil {
 		clusterDeployment := assistedinstaller.GetClusterDeploymentFromConfig(acp, clusterName)
 		_ = controllerutil.SetOwnerReference(acp, clusterDeployment, r.Scheme)
-		if _, err := ctrl.CreateOrUpdate(ctx, r.Client, clusterDeployment, func() error { return nil }); err != nil {
+		if err := util.CreateOrUpdate(ctx, r.Client, clusterDeployment); err != nil {
 			return err
 		}
 		ref, err := reference.GetReference(r.Scheme, clusterDeployment)

--- a/controlplane/internal/controller/utils.go
+++ b/controlplane/internal/controller/utils.go
@@ -1,0 +1,1 @@
+package controller

--- a/util/suite_test.go
+++ b/util/suite_test.go
@@ -1,0 +1,30 @@
+package util_test
+
+import (
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "k8s.io/api/apps/v1"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Util Suite")
+}
+
+var testScheme = runtime.NewScheme()
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	utilruntime.Must(v1.AddToScheme(testScheme))
+})

--- a/util/util.go
+++ b/util/util.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	controlplanev1alpha1 "github.com/openshift-assisted/cluster-api-agent/controlplane/api/v1alpha2"
 	logutil "github.com/openshift-assisted/cluster-api-agent/util/log"
 	corev1 "k8s.io/api/core/v1"
@@ -114,4 +116,21 @@ func GetWorkloadKubeconfig(
 		return nil, err
 	}
 	return kubeconfig, nil
+}
+
+// Create or update object
+func CreateOrUpdate(
+	ctx context.Context,
+	c client.Client,
+	obj client.Object,
+) error {
+	original := obj.DeepCopyObject().(client.Object)
+	key := client.ObjectKeyFromObject(obj)
+	if err := c.Get(ctx, key, obj); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		return c.Create(ctx, original)
+	}
+	return c.Update(ctx, original)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,53 @@
+package util_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-assisted/cluster-api-agent/util"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Utils", func() {
+	var (
+		ctx       = context.TODO()
+		k8sClient client.Client
+	)
+	BeforeEach(func() {
+		k8sClient = fakeclient.NewClientBuilder().WithScheme(testScheme).
+			Build()
+	})
+
+	It("should create a resource and then update it", func() {
+		replicas := int32(1)
+		deployment := v1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: "test-namespace"},
+			Spec: v1.DeploymentSpec{
+				Replicas: &replicas,
+			},
+		}
+		Expect(util.CreateOrUpdate(ctx, k8sClient, &deployment)).To(Succeed())
+
+		// test that this object was created as specs
+		retrievedDeployment := v1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &retrievedDeployment)).To(Succeed())
+		Expect(retrievedDeployment.Spec.Replicas).To(Equal(&replicas))
+
+		// update the object
+		replicas = 2
+		deployment.Spec.Replicas = &replicas
+		deployment.Annotations = map[string]string{"test": "test"}
+		Expect(util.CreateOrUpdate(ctx, k8sClient, &deployment)).To(Succeed())
+
+		// test that this object was updated as specs
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&deployment), &retrievedDeployment)).To(Succeed())
+		Expect("test").Should(BeKeyOf(retrievedDeployment.Annotations))
+		Expect("test").To(Equal(retrievedDeployment.Annotations["test"]))
+		Expect(retrievedDeployment.Spec.Replicas).To(Equal(&replicas))
+	})
+})


### PR DESCRIPTION
The usage of CreateOrUpdate in this project is mainly to avoid boilerplate when running both operations.
We do not change any value depending on the operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined deployment and update workflows by removing redundant methods and simplifying error handling.
- **New Features**
  - Introduced a new utility function for creating or updating Kubernetes objects, enhancing efficiency in resource management.
  - Added a new file for utility functions to support the updated workflows.
  - Added a test suite for utility functions to ensure reliability and correctness in deployment operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->