### PR TITLE
show diff when checking for generated files before returning error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/*
+dist/*
 Dockerfile.cross
 
 # Test binary, built with `go test -c`

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 
 .PHONY: check-generated-files
 check-generated-files: generate manifests generate-published-manifests generate-mocks
-	git add . && git diff --quiet && git diff --cached --quiet
+	git add . && git diff --staged --exit-code
 
 ##@ Dependencies
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the build's change verification process to focus solely on staged modifications, ensuring more reliable error signaling during builds.
  - Added `dist/*` to the `.gitignore` file to exclude distribution build files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->